### PR TITLE
Ensure certficates end up in cloud-front region + fmt

### DIFF
--- a/acm.tf
+++ b/acm.tf
@@ -1,4 +1,5 @@
 resource "aws_acm_certificate" "cert" {
+  provider                  = aws.use1
   domain_name               = var.zone
   validation_method         = "DNS"
   subject_alternative_names = ["www.${var.zone}"]
@@ -9,6 +10,7 @@ resource "aws_acm_certificate" "cert" {
 }
 
 resource "aws_acm_certificate_validation" "validation" {
+  provider                = aws.use1
   certificate_arn         = aws_acm_certificate.cert.arn
-  validation_record_fqdns = [ for record in aws_route53_record.cert_validation: record.fqdn ]
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,6 @@
 data "aws_region" "current" {}
+
+provider "aws" {
+  alias  = "use1"
+  region = "us-east-1"
+}

--- a/route53.tf
+++ b/route53.tf
@@ -29,16 +29,16 @@ resource "aws_route53_record" "redirect" {
 resource "aws_route53_record" "cert_validation" {
   # https://github.com/hashicorp/terraform-provider-aws/issues/10098#issuecomment-663562342
   for_each = {
-    for dvo in aws_acm_certificate.cert.domain_validation_options: dvo.domain_name => {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
   }
   name    = each.value.name
-  records = [ each.value.record ]
+  records = [each.value.record]
   type    = each.value.type
   zone_id = data.aws_route53_zone.zone.zone_id
 
-  ttl     = 60
+  ttl = 60
 }


### PR DESCRIPTION
Addresses problems with non US region deployments.
```The specified SSL certificate doesn't exist, isn't in us-east-1 region, isn't valid, or doesn't include a valid certificate chain```